### PR TITLE
Fix "is_post_type_archive was called incorrectly"

### DIFF
--- a/includes/article/article-restricted.php
+++ b/includes/article/article-restricted.php
@@ -133,7 +133,11 @@ function kbs_articles_exclude_restricted( $query )	{
 		return;
 	}
 
-	if ( is_admin() || ! is_post_type_archive( 'article' ) || ! $query->is_main_query() )	{
+	global $wp_query;
+
+	if ( is_admin() 
+	     || ( isset( $wp_query ) && ! is_post_type_archive( 'article' ) ) 
+	     || ! $query->is_main_query() )	{
 		return;
 	}
 


### PR DESCRIPTION
A filter on `pre_get_posts` was accessing `$wp_query` before it was set.

`Notice: Function is_post_type_archive was called incorrectly. Conditional query tags do not work before the query is run. Before then, they always return false. Please see [Debugging in WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/) for more information. (This message was added in version 3.1.0.) in /var/www/html/wp-includes/functions.php on line 5905 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:5905) in /var/www/html/wp-includes/pluggable.php on line 1435 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:5905) in /var/www/html/wp-includes/pluggable.php on line 1438`

Query monitor trace:

```
    is_post_type_archive()
    wp-includes/query.php:191
    kbs_articles_exclude_restricted()
    wp-content/plugins/kb-support/includes/article/article-restricted.php:145
    do_action_ref_array('pre_get_posts')
    wp-includes/plugin.php:565
    WP_Query->get_posts()
    wp-includes/class-wp-query.php:1881
    WP_Query->query()
    wp-includes/class-wp-query.php:3800
    WP_Query->__construct()
    wp-includes/class-wp-query.php:3932
    Automattic\W\B\U\BlockTemplateUtils::get_block_templates_from_db()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Utils/BlockTemplateUtils.php:728
    Automattic\W\B\U\CartCheckoutUtils::is_cart_block_default()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Utils/CartCheckoutUtils.php:17
    Automattic\W\B\D\S\Notices->init()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Domain/Services/Notices.php:45
    Automattic\W\B\D\Bootstrap->init()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Domain/Bootstrap.php:158
    Automattic\W\B\D\Bootstrap->__construct()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Domain/Bootstrap.php:80
    Automattic\W\B\Package::Automattic\W\B\{closure}()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Package.php:125
    Automattic\W\B\R\AbstractDependencyType->resolve_value()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Registry/AbstractDependencyType.php:42
    Automattic\W\B\R\SharedType->get()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Registry/SharedType.php:28
    Automattic\W\B\R\Container->get()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Registry/Container.php:96
    Automattic\W\B\Package::init()
    wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Package.php:44
    Automattic\WooCommerce\Packages::load_packages()
    wp-content/plugins/woocommerce/src/Packages.php:71
    Automattic\WooCommerce\Packages::on_init()
    wp-content/plugins/woocommerce/src/Packages.php:44
    do_action('plugins_loaded')
    wp-includes/plugin.php:517
```