### PR TITLE
Fix missing `$` with `jQuery`

### DIFF
--- a/assets/js/admin-conditions-scripts.js
+++ b/assets/js/admin-conditions-scripts.js
@@ -57,15 +57,15 @@ function kbsAdminConditions(object) {
 }
 
 // Dismiss admin notices
-$( document ).on( 'click', '.notice-kbs-dismiss .notice-dismiss', function () {
-	var notice = $( this ).closest( '.notice-kbs-dismiss' ).data( 'notice' );
+jQuery( document ).on( 'click', '.notice-kbs-dismiss .notice-dismiss', function () {
+	var notice = jQuery( this ).closest( '.notice-kbs-dismiss' ).data( 'notice' );
 
 	var postData         = {
 		notice    : notice,
 		action       : 'kbs_dismiss_notice'
 	};
 
-	$.ajax({
+	jQuery.ajax({
 			   type: 'POST',
 			   dataType: 'json',
 			   data: postData,


### PR DESCRIPTION
```
Uncaught TypeError: $ is not a function
    <anonymous> http://.../wp-content/plugins/kb-support/assets/js/admin-conditions-scripts.js?ver=1.5.90:60
[admin-conditions-scripts.js:60:2](http://.../wp-content/plugins/kb-support/assets/js/admin-conditions-scripts.js?ver=1.5.90)
    <anonymous> http://.../wp-content/plugins/kb-support/assets/js/admin-conditions-scripts.js?ver=1.5.90:60
```