### PR TITLE
Fix invalid `sprintf` placeholder

### DIFF
--- a/includes/api/class-kbs-api.php
+++ b/includes/api/class-kbs-api.php
@@ -172,7 +172,7 @@ class KBS_API extends WP_REST_Controller {
 				kbs_get_article_label_singular( true )
 			),
             'ticket_not_found'   => sprintf(
-				esc_html__( '% not found.', 'kb-support' ),
+				esc_html__( '%s not found.', 'kb-support' ),
 				kbs_get_article_label_singular()
 			),
 			'restricted_article' => sprintf(


### PR DESCRIPTION
```
Fatal error: Uncaught ValueError: Unknown format specifier "n" in /var/www/html/wp-content/plugins/kb-support/includes/api/class-kbs-api.php: 176
Stack trace:
#0 /var/www/html/wp-content/plugins/kb-support/includes/api/class-kbs-api.php(176): sprintf('% not found.', 'KB Article')
#1 /var/www/html/wp-content/plugins/kb-support/includes/api/endpoints/class-kbs-tickets-api.php(181): KBS_API->errors('no_auth')
#2 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1161): KBS_Tickets_API->get_items_permissions_check(Object(WP_REST_Request))
#3 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1041): WP_REST_Server->respond_to_request(Object(WP_REST_Request), '/kbs/v1/tickets', Array, NULL)
#4 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(431): WP_REST_Server->dispatch(Object(WP_REST_Request))
#5 /var/www/html/wp-includes/rest-api.php(418): WP_REST_Server->serve_request('/kbs/v1/tickets')
#6 /var/www/html/wp-includes/class-wp-hook.php(310): rest_api_loaded(Object(WP))
#7 /var/www/html/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters(NULL, Array)
#8 /var/www/html/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#9 /var/www/html/wp-includes/class-wp.php(398): do_action_ref_array('parse_request', Array)
#10 /var/www/html/wp-includes/class-wp.php(779): WP->parse_request('')
#11 /var/www/html/wp-includes/functions.php(1335): WP->main('')
#12 /var/www/html/wp-blog-header.php(16): wp()
#13 /var/www/html/index.php(17): require('/var/www/html/w...')
#14 {main
}
  thrown in /var/www/html/wp-content/plugins/kb-support/includes/api/class-kbs-api.php on line 176
```