### PR TITLE
Do not show `customer` in REST `_links` if ticket has no customer object

### DIFF
--- a/includes/api/endpoints/class-kbs-tickets-api.php
+++ b/includes/api/endpoints/class-kbs-tickets-api.php
@@ -1167,7 +1167,7 @@ class KBS_Tickets_API extends KBS_API {
 			);
 		}
 
-		if ( ! empty( $ticket->customer_id ) )	{
+		if ( ! empty( $ticket->customer_id ) && $ticket->customer_id > 0 )	{
 			$links['customer'] = array(
 				'href'       => rest_url( 'kbs/v1/customers/' . $ticket->customer_id ),
 				'embeddable' => true


### PR DESCRIPTION
`wp-json/kbs/v1/tickets` response `_links` contains:
```
"customer": [
        {
            "embeddable": true,
            "href": "http://localhost:8888/wp-json/kbs/v1/customers/-1"
        }
    ],
```
when there is no customer set on the ticket.

That is not a valid URL.