### PR TITLE
Remove list table "no callback" message

### DIFF
--- a/includes/admin/tickets/tickets.php
+++ b/includes/admin/tickets/tickets.php
@@ -202,7 +202,6 @@ function kbs_set_kbs_ticket_column_data( $column_name, $post_id ) {
 			break;
 
 		default:
-			echo esc_html__( 'No callback found for post column', 'kb-support' );
 			break;
 	}
 } // kbs_set_kbs_ticket_column_data


### PR DESCRIPTION
This is odd, it was removed in #224 but was still there today. 

The bug prevents third parties from adding a custom column to the tickets table, e.g. the Priority column here:

https://github.com/BrianHenryIE/bh-wp-kbs-ticket-priorities

now has `—No callback found` printed in every row of the table in the Priority column.