### PR TITLE
Move `composer/installers` from `require` to `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         "issues": "https://kb-support.com"
     },
     "require": {
-        "php": ">=5.4.0",
-        "composer/installers": "~1.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
+        "composer/installers": "~1.0"
         "phpunit/phpunit": "3.7.*",
         "phpunit/php-invoker": "1.1.3"
     },


### PR DESCRIPTION
The plugin doesn't use Composer's autoloader, so there's no way it's using composer/installers during normal operation.

It looks like it was just copied and pasted from another project: https://github.com/codemonkey-jack/kb-support/commit/d3aab490912e9ac4c6cdbcc14e150a621c36c92e